### PR TITLE
Allow api endpoint configuration to enable enterprise usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,13 @@ xcode_project_or_workspace = SomeProject.xcworkspace # or SomeProject.xcproject
 xcode_run_analyzer = 1 # or 0 to not run the analyzer
 xcode_run_test = 1 # or 0 to not run the tests
 xcode_create_archive = 1 # or 0 to not create an archive
+api_endpoint = https://enterprise.domain.com/api/v3
+web_endpoint = https://enterprise.domain.com
 ```
 
 Note that *xcode_devices* need to be pipe delimited. To get the list of available devices run the bot-devices command.
 The *xcode_server* can either be an ip address or a hostname.
+The api_endpoint and web_endpoint urls can be configured if you use a github enterprise setup, otherwise they can be omitted.
 
 Manually run **bot-sync-github** from the command line to make sure it works
 
@@ -71,6 +74,7 @@ Contributors
  - [Geoffery Nix](http://github.com/geoffnix)
  - [Two Bit Labs](http://twobitlabs.com/)
  - [Todd Huss](http://github.com/thuss)
+ - [Dave Kasper](http://github.com/dkasper)
 
 Copyright
 =========

--- a/lib/bot_config.rb
+++ b/lib/bot_config.rb
@@ -14,7 +14,7 @@ class BotConfig
     @config = ParseConfig.new(@filename)
 
     # Make sure every param is configured properly since param will throw an error for a missing key
-    [:xcode_server, :github_url, :github_repo, :github_access_token, :xcode_devices, :xcode_scheme, :xcode_project_or_workspace, :xcode_run_analyzer, :xcode_run_test, :xcode_create_archive].each do |key|
+    [:xcode_server, :github_url, :github_repo, :github_access_token, :xcode_devices, :xcode_scheme, :xcode_project_or_workspace, :xcode_run_analyzer, :xcode_run_test, :xcode_create_archive, :api_endpoint, :web_endpoint].each do |key|
       param key
     end
   end
@@ -57,6 +57,14 @@ class BotConfig
 
   def xcode_create_archive
     param :xcode_create_archive
+  end
+
+  def api_endpoint
+    param :api_endpoint
+  end
+
+  def web_endpoint
+    param :web_endpoint
   end
 
   def param(key)

--- a/lib/bot_config.rb
+++ b/lib/bot_config.rb
@@ -19,6 +19,10 @@ class BotConfig
     end
   end
 
+  def optional_params
+    [:api_endpoint, :web_endpoint]
+  end
+
   def xcode_server_hostname
     param :xcode_server
   end
@@ -69,7 +73,7 @@ class BotConfig
 
   def param(key)
     value = @config[key.to_s]
-    if (value.nil?)
+    if (value.nil? && !optional_params.include?(key))
       $stderr.puts "Missing configuration key #{key} in #{@filename}"
       exit 1
     end

--- a/lib/bot_github.rb
+++ b/lib/bot_github.rb
@@ -8,8 +8,8 @@ class BotGithub
   include Singleton
 
   def initialize
-    Octokit.api_endpoint = BotConfig.instance.api_endpoint 
-    Octokit.web_endpoint = BotConfig.instance.web_endpoint 
+    Octokit.api_endpoint = BotConfig.instance.api_endpoint if BotConfig.instance.api_endpoint 
+    Octokit.web_endpoint = BotConfig.instance.web_endpoint if BotConfig.instance.web_endpoint 
     @client = Octokit::Client.new :access_token => BotConfig.instance.github_access_token
     @client.login
   end

--- a/lib/bot_github.rb
+++ b/lib/bot_github.rb
@@ -8,6 +8,8 @@ class BotGithub
   include Singleton
 
   def initialize
+    Octokit.api_endpoint = BotConfig.instance.api_endpoint 
+    Octokit.web_endpoint = BotConfig.instance.web_endpoint 
     @client = Octokit::Client.new :access_token => BotConfig.instance.github_access_token
     @client.login
   end


### PR DESCRIPTION
Adding two optional parameters api_endpoint and web_endpoint. This enables using the system with an enterprise github installation on a custom domain. If the parameters are omitted the standard github.com api will be used.
